### PR TITLE
Update directory names in README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ SignBridge is a React Native application designed to facilitate seamless communi
 
 ## Running the Frontend
 To run the frontend application:
-1. Navigate to the `signbridge` directory: `cd signbridge`
+1. Navigate to the `signbridge-frontend` directory: `cd signbridge-frontend`
 2. Start the Expo app: `npx expo start`
 
 ## Running the Backend
 To run the backend server:
-1. Navigate to the `backend` directory: `cd backend`
+1. Navigate to the `signbridge-backend` directory: `cd signbridge-backend`
 2. Start the server: `python server.py`
 
 ## Running on the Web


### PR DESCRIPTION
This pull request updates the instructions in the `README.md` file to reflect the correct directory names for running both the frontend and backend applications. The changes help ensure that developers navigate to the appropriate directories when starting the project.

Documentation updates:

* Updated the frontend instructions to use the `signbridge-frontend` directory instead of `signbridge`.
* Updated the backend instructions to use the `signbridge-backend` directory instead of `backend`.